### PR TITLE
Add `in the fish shell,` to improve results

### DIFF
--- a/conf.d/github-copilot-cli.fish
+++ b/conf.d/github-copilot-cli.fish
@@ -13,7 +13,7 @@ end
 function __copilot_what-the-shell
     set TMPFILE (mktemp)
     trap 'rm -f $TMPFILE' EXIT
-    if github-copilot-cli what-the-shell $argv --shellout $TMPFILE
+    if github-copilot-cli what-the-shell 'in the fish shell,' $argv --shellout $TMPFILE
         if test -e $TMPFILE
             set FIXED_CMD (cat $TMPFILE)
             __fish_add_history $FIXED_CMD


### PR DESCRIPTION
`github-copilot-cli` is obviously tailored for bash/zsh syntax, but it can be nudged a bit to be fishy.

For example, without this change:

```
❯ !! print numbers from 0 to 10 skipping 5

 ──────────────────── Command ────────────────────

for i in {0..10}; do
  if [ $i -eq 5 ]; then
    continue;
  fi;
  echo $i;
done
```

This is not a valid fish script.

After prepending `in the fish shell,` to the query:

```
❯ !! print numbers from 0 to 10 skipping 5

 ──────────────────── Command ────────────────────

for i in (seq 0 10); if test $i -ne 5; echo $i; end; end
```

This works!


In my opinion, it's beneficial to include this prompt prefix globally, since fish syntax is what we always want. It's not perfect (Copilot is very obviously less competent with fish than bash), but it helps with many simple cases like outlined above.